### PR TITLE
fixed #86 i have added an close icon to close sidebar

### DIFF
--- a/quiz-maker/src/Components/Layout.js
+++ b/quiz-maker/src/Components/Layout.js
@@ -98,7 +98,7 @@ const Layout = ({ children }) => {
       </div>
       <div className="main-section">
         <button className="hamburger" onClick={toggleSidebar}>
-          <Icon icon="mdi:menu" />
+          { sidebarOpen ? <Icon icon="material-symbols:close" /> : <Icon icon="mdi:menu" /> }
         </button>
        <div className='layout-children'> {children} </div>
       </div>


### PR DESCRIPTION
Fixed #86 

i have fixed the closing icon bug now when the sidebar is open in mobile device you can see close icon for better user experience.

![image](https://github.com/user-attachments/assets/e4619c11-4191-40c4-bd18-9bd697ed7555)
