### PR TITLE
FIXES : #88 | Return To Attempted Route

### DIFF
--- a/quiz-maker/src/Components/Authorisation.js
+++ b/quiz-maker/src/Components/Authorisation.js
@@ -88,8 +88,9 @@ const Authorisation = () => {
                 email: "",
                 password: "",
             });
-
-            navigate("/dashboard");
+            const attemptedRoute = JSON.parse(localStorage.getItem('attemptedRoute'));
+            if(attemptedRoute) navigate(`/${attemptedRoute.path}`);
+            else navigate("/dashboard");
 
         } catch (err) {
             if (url === "/users/register") {

--- a/quiz-maker/src/Components/DashBoard.js
+++ b/quiz-maker/src/Components/DashBoard.js
@@ -25,6 +25,7 @@ const Dashboard = () => {
     localStorage.getItem("token") === null ||
     localStorage.getItem("token") === undefined
   ) {
+    localStorage.setItem("attemptedRoute", JSON.stringify({path}));
     window.location.href = "/login";
   }
 

--- a/quiz-maker/src/Components/Layout.js
+++ b/quiz-maker/src/Components/Layout.js
@@ -93,6 +93,7 @@ const Layout = ({ children }) => {
         </nav>
         <button className="logout-button" onClick={() => {
           localStorage.removeItem('token');
+          localStorage.removeItem('attemptedRoute');
           window.location.href = '/';
         }}>Logout <span><Icon icon="basil:logout-outline" /></span></button>
       </div>


### PR DESCRIPTION
fixes : #88 

Now users are redirected to intended secure route.

Ex :- Suppose user is **_not authenticated_** and he enters **_URL_** of **_profile page_** in the search bar and press enter then 
        user is **_redirected to login page_** and after successful login user is **_redirected to profile page_**, same with **_other 
        secure route also._**


https://github.com/user-attachments/assets/e28dec56-8099-4df9-b788-b8f540bcf707

