### PR TITLE
FIXES : #88 FURTHER | For /attempt/quizId and more

### DIFF
--- a/quiz-maker/src/Components/Authorisation.js
+++ b/quiz-maker/src/Components/Authorisation.js
@@ -89,7 +89,7 @@ const Authorisation = () => {
                 password: "",
             });
             const attemptedRoute = JSON.parse(localStorage.getItem('attemptedRoute'));
-            if(attemptedRoute) navigate(`/${attemptedRoute.path}`);
+            if(attemptedRoute) navigate(`/${attemptedRoute.pathURL}`);
             else navigate("/dashboard");
 
         } catch (err) {

--- a/quiz-maker/src/Components/DashBoard.js
+++ b/quiz-maker/src/Components/DashBoard.js
@@ -14,6 +14,7 @@ const Dashboard = () => {
   const [isLoading, setIsLoading] = useState(true);
 
   const path = window.location.pathname.split("/")[1];
+  const pathURL = window.location.pathname.split("/").join('/').substring(1);
 
   useEffect(() => {
     setTimeout(() => {
@@ -25,7 +26,7 @@ const Dashboard = () => {
     localStorage.getItem("token") === null ||
     localStorage.getItem("token") === undefined
   ) {
-    localStorage.setItem("attemptedRoute", JSON.stringify({path}));
+    localStorage.setItem("attemptedRoute", JSON.stringify({pathURL}));
     window.location.href = "/login";
   }
 

--- a/quiz-maker/src/Components/EditQuiz.js
+++ b/quiz-maker/src/Components/EditQuiz.js
@@ -7,7 +7,9 @@ const EditQuiz = () => {
     const navigate = useNavigate();
     //check user is logged in or not
     if (!localStorage.getItem('token') || localStorage.getItem('token') === null) {
-        navigate('/login');
+      const pathURL = window.location.pathname.split("/").join('/').substring(1);
+      localStorage.setItem("attemptedRoute", JSON.stringify({pathURL}));
+      window.location.href = "/login";
     }
     document.title = 'Edit Quiz | QuizMaster';
 

--- a/quiz-maker/src/Components/QuizDetails.js
+++ b/quiz-maker/src/Components/QuizDetails.js
@@ -5,10 +5,6 @@ import Layout from './Layout';
 
 const QuizDetails = () => {
     const navigate = useNavigate();
-    //check user is logged in or not
-    if (!localStorage.getItem('token')|| localStorage.getItem('token')===null) {
-        navigate('/login');
-    }
     document.title = 'Details Page | QuizMaster';
 
   const { quiz_id } = useParams();
@@ -17,6 +13,12 @@ const QuizDetails = () => {
   const [showConfirmDelete, setShowConfirmDelete] = useState(false);
   const [showConfirmEdit, setShowConfirmEdit] = useState(false);
 
+  //check user is logged in or not
+  if (localStorage.getItem('token') === null || localStorage.getItem('token') === undefined) {
+    const pathURL = window.location.pathname.split("/").join('/').substring(1);
+    localStorage.setItem("attemptedRoute", JSON.stringify({pathURL}));
+    window.location.href = "/login";
+  }
   useEffect(() => {
     const fetchQuiz = async () => {
       try {

--- a/quiz-maker/src/Components/Resultpage.js
+++ b/quiz-maker/src/Components/Resultpage.js
@@ -30,7 +30,9 @@ const ResultPage = () => {
   useEffect(() => {
     //check authontication
     if (localStorage.getItem('token') === null || localStorage.getItem('token') === undefined) {
-      navigate('/login');
+      const pathURL = window.location.pathname.split("/").join('/').substring(1);
+      localStorage.setItem("attemptedRoute", JSON.stringify({pathURL}));
+      return window.location.href = "/login";
     }
 
     const fetchQuizStats = async () => {

--- a/quiz-maker/src/Components/TestPage.js
+++ b/quiz-maker/src/Components/TestPage.js
@@ -17,6 +17,14 @@ const TakeTestPage = () => {
   const elapsedTimeRef = useRef(elapsedTime);
 
   useEffect(() => {
+    const pathURL = window.location.pathname.split("/").join('/').substring(1);
+    if (
+      localStorage.getItem("token") === null ||
+      localStorage.getItem("token") === undefined
+    ) {
+      localStorage.setItem("attemptedRoute", JSON.stringify({pathURL}));
+      window.location.href = "/login";
+    }
     const fetchStatus = async () => {
       try {
         const url = `${process.env.REACT_APP_BACKEND_URL}/quizzes/status/${quiz_id}`;


### PR DESCRIPTION
fixes : #88 further

Now users are **_redirected to intended secure route._**
**_Including_** `/attempt/quizId` `/result/quizid` `/quiz/quiz_id` `/edit-quiz/:quiz_id`


https://github.com/user-attachments/assets/e02ba372-8cdf-461e-a752-2b6e9c7e3f6b

